### PR TITLE
explicitly set the xmrig-cuda loader when using cuda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN set -xe; \
     rm -rf /var/lib/apt/lists/*
 COPY --from=build-runner /xmrig/xmrig /xmrig/xmrig
 COPY --from=build-runner /xmrig/src/config.json /xmrig/config.json
-COPY --from=build-cuda-plugin /xmrig-cuda/build/libxmrig-cuda.so /usr/lib64/
+COPY --from=build-cuda-plugin /xmrig-cuda/build/libxmrig-cuda.so /usr/local/lib/
 
 
 ENV POOL_USER="44vjAVKLTFc7jxTv5ij1ifCv2YCFe3bpTgcRyR6uKg84iyFhrCesstmWNUppRCrxCsMorTP8QKxMrD3QfgQ41zsqMgPaXY5" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -91,7 +91,7 @@ fi
 OTHERS_OPTS=$OTHERS_OPTS" -p ${WORKERNAME}"
 
 if [ "${CUDA}" == "true" ]; then
-    OTHERS_OPTS=$OTHERS_OPTS" --cuda"
+    OTHERS_OPTS=$OTHERS_OPTS" --cuda --cuda-loader=/usr/local/lib/libxmrig-cuda.so"
     jq '.cuda.enabled = true' config.json > config.json.tmp && mv config.json.tmp config.json
     jq '.cpu.enabled = false' config.json > config.json.tmp && mv config.json.tmp config.json
 fi


### PR DESCRIPTION
When using with Cuda, it has a hard time finding the xmrig-cuda loader, so instead, set the path explicitly.